### PR TITLE
Better exception handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,7 +1374,7 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pg-snap"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-snap"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 
+use anyhow::Result;
 use tokio::fs::File;
 
 use crate::db::Constraint;
@@ -41,7 +42,7 @@ impl PgTable {
         }
     }
 
-    pub async fn save_to_file(&self, path: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn save_to_file(&self, path: PathBuf) -> Result<()> {
         // Serialize the struct to binary
         let serialized_data = bincode::serialize(self)?;
 
@@ -52,7 +53,7 @@ impl PgTable {
         Ok(())
     }
 
-    pub async fn from_file(path: PathBuf) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn from_file(path: PathBuf) -> Result<Self> {
         // Open the file and read its contents
         let mut file = File::open(path).await?;
         let mut buffer = Vec::new();

--- a/src/table.rs
+++ b/src/table.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use tokio::{fs::File, io::BufWriter};
 
 use crate::{db::Db, utils::read_first_line};
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use bytes::Bytes;
 use futures_util::StreamExt;
 use tokio::io::AsyncWriteExt;
@@ -52,7 +52,7 @@ impl Table {
     ) -> anyhow::Result<u64> {
         let mut client = self.db_conn.connect().await?;
         let file = tokio::fs::File::open(out_file).await?;
-        let first_line = read_first_line(out_file).expect("Failed to read the first line");
+        let first_line = read_first_line(out_file).context("Failed to read the first line")?;
 
         let copy_cmd = match schema {
             Some(schema) => format!(


### PR DESCRIPTION
Instead of printing the rust backtrace like so:
```
RUST_BACKTRACE=1 pg_snap restore --username "postgres" --db videahealth-dev --host "localhost" --password "postgres"
thread 'main' panicked at src/restore/mod.rs:264:10:
Failed to execute pg_dump command.: Os { code: 2, kind: NotFound, message: "No such file or directory" }
stack backtrace:
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace. 
```
Print the error in a more user friendly way like so:
```
ERROR: Error running restore command:
        pg_restore command not found in system PATH
```

Uses anyhow context: https://docs.rs/anyhow/latest/anyhow/trait.Context.html
Use paradigm described here: https://docs.rs/anyhow/1.0.56/anyhow/struct.Error.html#display-representations
```rust
use anyhow::{Context, Result};

fn main() {
    if let Err(err) = try_main() {
        eprintln!("ERROR: {}", err);
        err.chain().skip(1).for_each(|cause| eprintln!("because: {}", cause));
        std::process::exit(1);
    }
}

fn try_main() -> Result<()> {
    ...
}
```